### PR TITLE
Fix failing interop tests

### DIFF
--- a/lib/grpc/adapter/cowboy.ex
+++ b/lib/grpc/adapter/cowboy.ex
@@ -180,12 +180,7 @@ defmodule GRPC.Adapter.Cowboy do
         num_acceptors: @default_num_acceptors,
         socket_opts: socket_opts(port, opts)
       },
-      %{
-        env: %{dispatch: dispatch},
-        inactivity_timeout: idle_timeout,
-        settings_timeout: idle_timeout,
-        stream_handlers: [:grpc_stream_h]
-      }
+      opts
     ]
   end
 


### PR DESCRIPTION
Fixes failing test in https://github.com/brexhq/grpc-elixir/pull/5/checks?check_run_id=433921484.

Seems likely that this was caused my a merge conflict error. This is the only change we needed (https://github.com/brexhq/grpc-elixir/pull/2/files), and the way the `opts` parameter was being passed in changed upstream. As a result, our merge kept around the old `opts` parameter which didn't include the new `frame_rate` and `stream_rate` settings.

Signed-off-by: Adnan Abdulhussein <adnan@brex.com>