### PR TITLE
handle and propegate errors from adapter.rec_data_or_trailers

### DIFF
--- a/lib/grpc/stub.ex
+++ b/lib/grpc/stub.ex
@@ -459,6 +459,9 @@ defmodule GRPC.Stub do
 
       {:trailers, trailers} ->
         {:ok, acc, GRPC.Transport.HTTP2.decode_headers(trailers)}
+
+      {:error, err} ->
+        {:error, err}
     end
   end
 


### PR DESCRIPTION
When a connection is closed prior to sending a response the gun adapter returns a {:error, %GRPC.RPCError{}} that is unmatched in the body of recv_body. This results in a CaseClauseError being raised to the client application. This PR propagates the error to avoid raising an exception that avoids crashing the client process preventing a retry. 