### PR TITLE
[elixir-2025] add parentheses to __rpc_calls__ invocations

### DIFF
--- a/lib/grpc/server.ex
+++ b/lib/grpc/server.ex
@@ -47,7 +47,7 @@ defmodule GRPC.Server do
       codecs = opts[:codecs] || [GRPC.Codec.Proto]
       compressors = opts[:compressors] || []
 
-      Enum.each(service_mod.__rpc_calls__, fn {name, _, _} = rpc ->
+      Enum.each(service_mod.__rpc_calls__(), fn {name, _, _} = rpc ->
         func_name = name |> to_string |> Macro.underscore() |> String.to_atom()
         path = "/#{service_name}/#{name}"
         grpc_type = GRPC.Service.grpc_type(rpc)

--- a/lib/grpc/service.ex
+++ b/lib/grpc/service.ex
@@ -28,7 +28,7 @@ defmodule GRPC.Service do
     rpc_calls = Module.get_attribute(env.module, :rpc_calls)
 
     quote do
-      def __rpc_calls__, do: unquote(rpc_calls |> Macro.escape() |> Enum.reverse())
+      def __rpc_calls__(), do: unquote(rpc_calls |> Macro.escape() |> Enum.reverse())
     end
   end
 

--- a/lib/grpc/stub.ex
+++ b/lib/grpc/stub.ex
@@ -59,7 +59,7 @@ defmodule GRPC.Stub do
       service_mod = opts[:service]
       service_name = service_mod.__meta__(:name)
 
-      Enum.each(service_mod.__rpc_calls__, fn {name, {_, req_stream}, {_, res_stream}} = rpc ->
+      Enum.each(service_mod.__rpc_calls__(), fn {name, {_, req_stream}, {_, res_stream}} = rpc ->
         func_name = name |> to_string |> Macro.underscore()
         path = "/#{service_name}/#{name}"
         grpc_type = GRPC.Service.grpc_type(rpc)


### PR DESCRIPTION
Add missing parentheses to __rpc_calls__ function calls across server.ex, service.ex and stub.ex to comply with Elixir 1.18's stricter function call syntax requirements.